### PR TITLE
Fix project.conf to serve static, media

### DIFF
--- a/salt/root/project/files/apache2/project.conf.jinja
+++ b/salt/root/project/files/apache2/project.conf.jinja
@@ -2,24 +2,20 @@
 
     Alias /robots.txt {{ salt['pillar.get']('project:django:path') }}{{ salt['pillar.get']('project:django:settings:static') }}/robots.txt
     Alias /favicon.ico {{ salt['pillar.get']('project:django:path') }}{{ salt['pillar.get']('project:django:settings:static') }}/favicon.ico
-    
+
     Alias /media/ {{ salt['pillar.get']('project:django:path') }}{{ salt['pillar.get']('project:django:settings:media') }}/
     Alias /static/ {{ salt['pillar.get']('project:django:path') }}{{ salt['pillar.get']('project:django:settings:static') }}/
-    
-    <Directory {{ salt['pillar.get']('project:django:path') }}{{ salt['pillar.get']('project:django:settings:static') }}>
-        Require all granted
-    </Directory>
-    
+
     <Directory {{ salt['pillar.get']('project:django:path') }}{{ salt['pillar.get']('project:django:settings:media') }}>
         Require all granted
     </Directory>
-    
-    ProxyPass / http://{{ salt['pillar.get']('project:environment:host') }}:{{ salt['pillar.get']('project:environment:port') }}
-    
-    <Directory {{ salt['pillar.get']('project:django:path') }}>
-        <Files wsgi.py>
-            Require all granted
-        </Files>
+
+    <Directory {{ salt['pillar.get']('project:django:path') }}{{ salt['pillar.get']('project:django:settings:static') }}>
+        Require all granted
     </Directory>
+
+    ProxyPass /media/ !
+    ProxyPass /static/ !
+    ProxyPass / http://{{ salt['pillar.get']('project:environment:host') }}:{{ salt['pillar.get']('project:environment:port') }}
 
 </VirtualHost>


### PR DESCRIPTION
Fixes /etc/apache2/sites-available/project.conf to serve files in /static and /media directories.